### PR TITLE
[CSP] `disposition` プロパティが存在しない場合は null で DB 保管する

### DIFF
--- a/node/@types/db.d.ts
+++ b/node/@types/db.d.ts
@@ -7,7 +7,7 @@ declare namespace ReportDB {
 		originalPolicy: string;
 		sourceFile: string | undefined;
 		sample: string | undefined;
-		disposition: string;
+		disposition: string | undefined;
 		statusCode: number;
 		lineNumber: number | undefined;
 		columnNumber: number | undefined;

--- a/node/src/controller/csp.test.ts
+++ b/node/src/controller/csp.test.ts
@@ -6,7 +6,7 @@ import { parseRequestJson } from './csp.js';
 
 const origin = env('CSP_ALLOW_ORIGINS', 'string[]').at(0)!;
 
-await test('getReporting()', async (t) => {
+await test('parseRequestJson()', async (t) => {
 	await t.test('Reporting Api v1', () => {
 		const reportings = parseRequestJson(
 			[
@@ -130,7 +130,7 @@ await test('getReporting()', async (t) => {
 						documentURL: 'https://example.com/',
 						effectiveDirective: 'effective-directive',
 						originalPolicy: 'original-policy',
-						disposition: 'report',
+						disposition: undefined,
 						statusCode: 11,
 					},
 					type: 'csp-violation',

--- a/node/src/controller/csp.ts
+++ b/node/src/controller/csp.ts
@@ -16,7 +16,7 @@ interface CSPViolationReportBody {
 	originalPolicy: string; // 元のポリシー
 	sourceFile?: string;
 	sample?: string; // 違反の原因となったインラインスクリプト、イベントハンドラー、またはスタイルの最初の40文字
-	disposition: 'enforce' | 'report';
+	disposition: 'enforce' | 'report' | undefined; // undefined は Firefox, Safari の互換性確保のために必要
 	statusCode: number;
 	lineNumber?: number;
 	columnNumber?: number;
@@ -104,7 +104,7 @@ export const parseRequestJson = (
 		documentURL: cspReport['document-uri'],
 		effectiveDirective: cspReport['effective-directive'],
 		originalPolicy: cspReport['original-policy'],
-		disposition: cspReport.disposition ?? 'report',
+		disposition: cspReport.disposition ?? undefined,
 		statusCode: cspReport['status-code'],
 	};
 	if (cspReport.referrer !== undefined) {

--- a/views/csp_mail.ejs
+++ b/views/csp_mail.ejs
@@ -7,6 +7,7 @@
 				padding: 0.25em 0.5em;
 				border-radius: 0.25em;
 				color: #fff;
+				background-color: #767676;
 				line-height: 1;
 			}
 
@@ -44,8 +45,10 @@
 		<p>
 			<%_ if (body.disposition === 'enforce') { _%>
 			<span class="disposition -enforce">Enforce</span>
-			<%_ } else { _%>
+			<%_ } else if (body.disposition === 'report') { _%>
 			<span class="disposition -report">Report Only</span>
+			<%_ } else { _%>
+			<span class="disposition">Unknown</span>
 			<%_ } _%>
 		</p>
 


### PR DESCRIPTION
#80 で強制的に `report` 扱いとしたが、やはり不適切なので null とする。