### PR TITLE
フィルタリングの `sourceFile` を正規表現でも指定できるように改修

### DIFF
--- a/node/src/config/csp.ts
+++ b/node/src/config/csp.ts
@@ -1,7 +1,7 @@
 interface Filter {
 	blockedURL?: string;
 	effectiveDirective: string;
-	sourceFile?: string;
+	sourceFile?: string | RegExp;
 	sample?: string;
 }
 
@@ -10,7 +10,13 @@ const noticeFilter: Filter[] = [
 	{ blockedURL: 'https://analytics.w0s.jp/matomo/matomo.js', effectiveDirective: 'script-src' }, // old Safari
 	{ blockedURL: 'data', effectiveDirective: 'media-src' }, // moz-extension (NoScript)
 	{ blockedURL: 'inline', effectiveDirective: 'script-src-elem', sourceFile: 'moz-extension' }, // moz-extension (Violentmonkey)
+	{
+		blockedURL: 'inline',
+		effectiveDirective: 'script-src-elem',
+		sourceFile: /^safari-web-extension:\/\/[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}\/js\/utils\.js$/,
+	},
 	{ blockedURL: 'trusted-types-policy', effectiveDirective: 'trusted-types', sourceFile: 'chrome-extension', sample: 'dompurify' },
+	{ blockedURL: 'trusted-types-policy', effectiveDirective: 'trusted-types', sourceFile: 'chrome-extension', sample: 'sanitizer' },
 	{ blockedURL: 'eval', effectiveDirective: 'script-src', sourceFile: 'chrome-extension' },
 	{ blockedURL: 'wasm-eval', effectiveDirective: 'script-src', sourceFile: 'chrome-extension' },
 	{ effectiveDirective: 'fenced-frame-src' },

--- a/node/src/controller/csp.test.ts
+++ b/node/src/controller/csp.test.ts
@@ -330,28 +330,53 @@ await test('noticeFilter()', async (t) => {
 		);
 	});
 
-	await t.test('some match (except: sourceFile)', () => {
-		assert.deepEqual(
-			noticeFilter([
-				{
-					age: 0,
-					body: {
-						documentURL: 'http://example.com/documentURL',
-						blockedURL: 'trusted-types-policy',
-						effectiveDirective: 'trusted-types',
-						originalPolicy: 'originalPolicy',
-						sourceFile: 'chrome-extension2',
-						sample: 'dompurify',
-						disposition: 'enforce',
-						statusCode: 11,
+	await t.test('some match (except: sourceFile)', async (t2) => {
+		await t2.test('string', () => {
+			assert.deepEqual(
+				noticeFilter([
+					{
+						age: 0,
+						body: {
+							documentURL: 'http://example.com/documentURL',
+							blockedURL: 'trusted-types-policy',
+							effectiveDirective: 'trusted-types',
+							originalPolicy: 'originalPolicy',
+							sourceFile: 'chrome-extension2',
+							sample: 'dompurify',
+							disposition: 'enforce',
+							statusCode: 11,
+						},
+						type: 'csp-violation',
+						url: 'https://example.com/',
+						user_agent: 'Mozilla/5.0...',
 					},
-					type: 'csp-violation',
-					url: 'https://example.com/',
-					user_agent: 'Mozilla/5.0...',
-				},
-			]).length,
-			1,
-		);
+				]).length,
+				1,
+			);
+		});
+
+		await t2.test('RegExp', () => {
+			assert.deepEqual(
+				noticeFilter([
+					{
+						age: 0,
+						body: {
+							documentURL: 'http://example.com/documentURL',
+							blockedURL: 'inline',
+							effectiveDirective: 'script-src-elem',
+							originalPolicy: 'originalPolicy',
+							sourceFile: 'safari-web-extension://1234ABCD-12AB-12AB-12AB-123456ABCDEF/js/utils2.js',
+							disposition: 'enforce',
+							statusCode: 11,
+						},
+						type: 'csp-violation',
+						url: 'https://example.com/',
+						user_agent: 'Mozilla/5.0...',
+					},
+				]).length,
+				1,
+			);
+		});
 	});
 
 	await t.test('some match (except: sample)', () => {
@@ -378,28 +403,53 @@ await test('noticeFilter()', async (t) => {
 		);
 	});
 
-	await t.test('all match', () => {
-		assert.deepEqual(
-			noticeFilter([
-				{
-					age: 0,
-					body: {
-						documentURL: 'http://example.com/documentURL',
-						blockedURL: 'trusted-types-policy',
-						effectiveDirective: 'trusted-types',
-						originalPolicy: 'originalPolicy',
-						sourceFile: 'chrome-extension',
-						sample: 'dompurify',
-						disposition: 'enforce',
-						statusCode: 11,
+	await t.test('all match', async (t2) => {
+		await t2.test('string', () => {
+			assert.deepEqual(
+				noticeFilter([
+					{
+						age: 0,
+						body: {
+							documentURL: 'http://example.com/documentURL',
+							blockedURL: 'trusted-types-policy',
+							effectiveDirective: 'trusted-types',
+							originalPolicy: 'originalPolicy',
+							sourceFile: 'chrome-extension',
+							sample: 'dompurify',
+							disposition: 'enforce',
+							statusCode: 11,
+						},
+						type: 'csp-violation',
+						url: 'https://example.com/',
+						user_agent: 'Mozilla/5.0...',
 					},
-					type: 'csp-violation',
-					url: 'https://example.com/',
-					user_agent: 'Mozilla/5.0...',
-				},
-			]).length,
-			0,
-		);
+				]).length,
+				0,
+			);
+		});
+
+		await t2.test('RegExp', () => {
+			assert.deepEqual(
+				noticeFilter([
+					{
+						age: 0,
+						body: {
+							documentURL: 'http://example.com/documentURL',
+							blockedURL: 'inline',
+							effectiveDirective: 'script-src-elem',
+							originalPolicy: 'originalPolicy',
+							sourceFile: 'safari-web-extension://1234ABCD-12AB-12AB-12AB-123456ABCDEF/js/utils.js',
+							disposition: 'enforce',
+							statusCode: 11,
+						},
+						type: 'csp-violation',
+						url: 'https://example.com/',
+						user_agent: 'Mozilla/5.0...',
+					},
+				]).length,
+				0,
+			);
+		});
 	});
 });
 

--- a/node/src/controller/csp.ts
+++ b/node/src/controller/csp.ts
@@ -162,7 +162,11 @@ export const noticeFilter = (reportingList: ReportingApiV1CSP[]): ReportingApiV1
 					return false;
 				}
 				if (sourceFile !== undefined && body.sourceFile !== undefined) {
-					if (sourceFile !== body.sourceFile) {
+					if (typeof sourceFile === 'string') {
+						if (sourceFile !== body.sourceFile) {
+							return false;
+						}
+					} else if (!sourceFile.test(body.sourceFile)) {
 						return false;
 					}
 				}


### PR DESCRIPTION
safari-web-extension 対応