### PR TITLE
SQL の UPDATE 文の構文ミスを修正

### DIFF
--- a/node/src/util/sql.test.ts
+++ b/node/src/util/sql.test.ts
@@ -134,7 +134,7 @@ await test('prepareUpdate', () => {
 		},
 	);
 
-	assert.equal(sqlSet, 'string = :string AND undefined = :undefined');
+	assert.equal(sqlSet, 'string = :string, undefined = :undefined');
 	assert.equal(sqlWhere, 'number = :number AND undefined IS NULL');
 	assert.deepEqual(bindParams, {
 		':string': 'foo',

--- a/node/src/util/sql.ts
+++ b/node/src/util/sql.ts
@@ -142,7 +142,7 @@ export const prepareUpdate = (
 
 	const sqlSet = setArray
 		.map(([key]) => `${key} = :${key}`)
-		.join(' AND ');
+		.join(', ');
 
 	const sqlWhere = whereArray
 		.map(([key, value]) => {


### PR DESCRIPTION
ただし report.w0s.jp では UPDATE 文を使用していないので偶然問題は起こっていなかった。