### PR TITLE
[CSP] 通知フィルターデータ追加

### DIFF
--- a/node/src/config/csp.ts
+++ b/node/src/config/csp.ts
@@ -15,7 +15,9 @@ const noticeFilter: Filter[] = [
 	{ effectiveDirective: 'script-src', blockedURL: 'eval', sourceFile: 'chrome-extension' },
 	{ effectiveDirective: 'script-src', blockedURL: 'wasm-eval', sourceFile: 'chrome-extension' },
 	{ effectiveDirective: 'script-src-elem', blockedURL: 'inline', sourceFile: 'moz-extension' }, // moz-extension (Violentmonkey)
+	{ effectiveDirective: 'script-src-elem', blockedURL: 'inline', sourceFile: 'sandbox eval code' },
 	{ effectiveDirective: 'script-src-elem', blockedURL: 'inline', sourceFile: 'user-script' }, // iPad
+	{ effectiveDirective: 'script-src-elem', blockedURL: 'https://analytics.w0s.jp/matomo/matomo.js' },
 	{
 		effectiveDirective: 'script-src-elem',
 		blockedURL: 'inline',
@@ -26,7 +28,6 @@ const noticeFilter: Filter[] = [
 		blockedURL: 'inline',
 		sourceFile: /^safari-web-extension:\/\/[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}\/js\/utils\.js$/v,
 	},
-	{ effectiveDirective: 'script-src-elem', blockedURL: 'inline', sourceFile: 'sandbox eval code' },
 	{ effectiveDirective: 'trusted-types', blockedURL: 'trusted-types-policy', sourceFile: 'chrome-extension', sample: 'default' },
 	{ effectiveDirective: 'trusted-types', blockedURL: 'trusted-types-policy', sourceFile: 'chrome-extension', sample: 'default2' },
 	{ effectiveDirective: 'trusted-types', blockedURL: 'trusted-types-policy', sourceFile: 'chrome-extension', sample: 'dompurify' },


### PR DESCRIPTION
`script-src-elem` で指定しているはずのアクセス解析タグがなぜか頻繁に検知されるためフィルターでブロックする